### PR TITLE
Add X-Forwarded-Proto Header to haproxy.cfg

### DIFF
--- a/contexts/haproxy/haproxy.cfg
+++ b/contexts/haproxy/haproxy.cfg
@@ -30,6 +30,7 @@ frontend http
 
 frontend https
     bind :8443 ssl crt /usr/local/etc/haproxy/ssl/combined.pem
+	http-request set-header X-Forwarded-Proto https
 
     use_backend appnav if { path_beg /applicationNavigator }
     use_backend accessmgmt if { path_beg /BannerAccessMgmt }


### PR DESCRIPTION
Added X-Forwarded-Proto in haproxy.cfg in order to avoid SSL termination for Health check endpoints (url/health, url/status, url.ws/status)