### PR TITLE
configured servicesUrl in web.xml for health endpoints

### DIFF
--- a/contexts/scripts/Dockerfile_tomcat.j2
+++ b/contexts/scripts/Dockerfile_tomcat.j2
@@ -14,6 +14,8 @@ WORKDIR /build
     COPY ["footer*.properties", "/tmp/"]
     RUN cat /tmp/footer*.properties >> config.properties && \
         sed -i "s/<session-timeout>60<\/session-timeout>/<session-timeout>\${banner9.session_timeout}<\/session-timeout>/" ../web.xml
+		sed -i -e '/<!--\s*<init-param>/,/<\/init-param>\s*-->/ s/<!--\s*//; s/\s*-->//' -e "s|<param-value>ellucian.com:8080/\(.*\)/status</param-value>|<param-value>{{BANNER9_ROOT}}/\1/status</param-value>|g" -e "s|<param-value>ellucian.com|<param-value>{{BANNER9_ROOT}}|g" ../web.xml
+
 
 {% elif context in ['ema'] %}
     COPY ["EllucianMessagingAdapter.zip", "."]
@@ -34,6 +36,12 @@ WORKDIR /build
     WORKDIR /build/{{ app_name }}/WEB-INF/classes/
     COPY ["footer*.groovy", "/tmp/"]
     RUN sed -i "s,\^APP_NAME\^,{{ app_name }}," /tmp/footer.groovy
+	
+	{% if context in ['accessmgmt'] %}
+	    RUN sed -i "s/<session-timeout>60<\/session-timeout>/<session-timeout>\${banner9.session_timeout}<\/session-timeout>/" ../web.xml
+		RUN sed -i -e '/<!--\s*<init-param>/,/<\/init-param>\s*-->/ s/<!--\s*//; s/\s*-->//' -e "s|<param-value>ellucian.com:8080/\(.*\)/status</param-value>|<param-value>{{BANNER9_ROOT}}/\1/status</param-value>|g" -e "s|<param-value>ellucian.com|<param-value>{{BANNER9_ROOT}}|g" ../web.xml
+
+	{% endif %}
 
     {% if context.endswith('api') %}
         # echo a newline to the .groovy file before the adding the footer

--- a/contexts/scripts/make_tomcat_dockerfile.py
+++ b/contexts/scripts/make_tomcat_dockerfile.py
@@ -5,7 +5,7 @@ import sys
 
 from jinja2 import Template
 
-from config import CONTEXT_APPS, HUBADO_HOST_UID, TIMEZONE
+from config import CONTEXT_APPS, BANNER9_ROOT, HUBADO_HOST_UID, TIMEZONE
 
 
 dockerfile_path = sys.argv[1]
@@ -15,6 +15,11 @@ with open("/usr/local/share/Dockerfile_tomcat.j2") as f:
     template = Template(f.read())
 
 app_name = CONTEXT_APPS[context][0]
+if len(CONTEXT_APPS[context]) > 1:
+    worksp_name = CONTEXT_APPS[context][1]
+else:
+    # Handle the case where there is only one element in the array
+    worksp_name = ''
 hubado_host_uid = HUBADO_HOST_UID
 timezone = TIMEZONE
 


### PR DESCRIPTION
Passed BANNER9_ROOT into make_tomcat_dockerfile for user by the Dockerfile_tomcat.j2 script. Then I wrote some sed commands to uncomment servicesUrl init-params in the HealthServlet and StatusServlet for accessmgmt and admincommon while replacing the urls for each application with context specific urls.

This needs testing before a full commit.